### PR TITLE
ci: check installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install OpenVINO
         uses: ./
         with:
-          version: 2022.2
+          version: 2022.3
           release: rhel8
       - name: List files
         run: find $OPENVINO_INSTALL_DIR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,10 @@ jobs:
         run: find $OPENVINO_INSTALL_DIR
         shell: bash
       - name: Check installation
-        run: $OPENVINO_INSTALL_DIR/setupvars.sh
-        if: matrix.os != 'windows-latest'
-      - name: Check installation
-        run: ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
-        if: matrix.os == 'windows-latest'
-
+        run: cargo run
+        working-directory: integration-tests
+        env:
+          RUST_LOG: debug
 
   old:
     name: Spot-check old archive
@@ -52,7 +50,10 @@ jobs:
       - name: List files
         run: find $OPENVINO_INSTALL_DIR
       - name: Check installation
-        run: $OPENVINO_INSTALL_DIR/setupvars.sh
+        run: cargo run
+        working-directory: integration-tests
+        env:
+          RUST_LOG: debug
 
   apt:
     name: Check installing APT packages
@@ -74,5 +75,10 @@ jobs:
           apt-cache depends openvino-2022.3.0 --installed
           dpkg --listfiles libopenvino-2022.3.0
         shell: bash
-      - name: Check installation
+      - name: Check installed libraries
         run: ldconfig -p | grep openvino
+      - name: Check installation
+        run: cargo run
+        working-directory: integration-tests
+        env:
+          RUST_LOG: debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
         working-directory: integration-tests
         env:
           RUST_LOG: debug
+          RUST_BACKTRACE: 1
 
   old:
     name: Spot-check old archive
@@ -54,6 +55,7 @@ jobs:
         working-directory: integration-tests
         env:
           RUST_LOG: debug
+          RUST_BACKTRACE: 1
 
   apt:
     name: Check installing APT packages
@@ -82,3 +84,4 @@ jobs:
         working-directory: integration-tests
         env:
           RUST_LOG: debug
+          RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        #os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Install OpenVINO

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install OpenVINO
         uses: ./
+        with:
+          version: 2022.3
       - name: List files
         run: find $OPENVINO_INSTALL_DIR
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
       - name: List files
         run: find $OPENVINO_INSTALL_DIR
         shell: bash
+      - name: List environment
+        run: env
+        shell: bash
       - name: Check installation
         run: cargo run
         working-directory: integration-tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ GPG-PUB-KEY*
 node_modules
 *.tgz
 *.zip
+filetree.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 install-openvino-action
 =======================
 
-Install OpenVINO as a step in a GitHub workflow.
+Install OpenVINO as a step in a GitHub workflow; sets `OPENVINO_INSTALL_DIR` in the GitHub
+environment.
 
 ### Use
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   - run: |
       sudo apt-get install -y libpugixml1v5
     shell: bash
-    if: ${{ !inputs.apt && startsWith(runner.os, 'ubuntu') }}
+    if: ${{ !inputs.apt && runner.os == 'Linux' }}
   - run: |
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -50,13 +50,13 @@ runs:
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV
     shell: bash
-    if: ${{ !inputs.apt && !startsWith(runner.os, 'windows') }}
+    if: ${{ inputs.apt == 'false' && !startsWith(runner.os, 'windows') }}
   - run: |
       source ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
       env >> $GITHUB_ENV
     shell: bash
     if: ${{ !inputs.apt && startsWith(runner.os, 'windows') }}
   - run: |
-      find $OPENVINO_INSTALL_DIR -name 'libopenvino.so*' | xargs ldd
+      find $OPENVINO_INSTALL_DIR -name 'libopenvino*.so*' | xargs ldd
     shell: bash
     if: ${{ runner.os == 'Linux' }}

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   - run: |
       sudo apt-get install -y libpugixml1v5
     shell: bash
-    if: ${{ !inputs.apt && runner.os == 'Linux' }}
+    if: ${{ runner.os == 'Linux' }}
   - run: |
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ runs:
       INPUT_APT: ${{ inputs.apt }}
   - run: |
       sudo apt-get install -y libpugixml1v5
+    shell: bash
     if: ${{ !inputs.apt && !startsWith(runner.os, 'ubuntu') }}
   - run: |
       source $OPENVINO_INSTALL_DIR/setupvars.sh

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,9 @@ runs:
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV
     shell: bash
-    if: ${{ !startsWith(runner.os, 'windows') }}
+    if: ${{ !inputs.apt && !startsWith(runner.os, 'windows') }}
   - run: |
       source ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
       env >> $GITHUB_ENV
     shell: bash
-    if: startsWith(runner.os, 'windows')
+    if: ${{ !inputs.apt && startsWith(runner.os, 'windows') }}

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   - run: echo ${{ runner.os }}
     shell: bash
   - run: |
-      sudo apt-get install -y libpugixml1v5
+      sudo apt-get install -y libpugixml1v5 libtbb2
     shell: bash
     if: ${{ runner.os == 'Linux' }}
   - run: |

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ runs:
       INPUT_ARCH: ${{ inputs.arch }}
       INPUT_APT: ${{ inputs.apt }}
   - run: |
+      sudo apt-get install -y libpugixml1v5
+    if: ${{ !inputs.apt && !startsWith(runner.os, 'ubuntu') }}
+  - run: |
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   - run: |
       sudo apt-get install -y libpugixml1v5
     shell: bash
-    if: ${{ !inputs.apt && !startsWith(runner.os, 'ubuntu') }}
+    if: ${{ !inputs.apt && startsWith(runner.os, 'ubuntu') }}
   - run: |
       source $OPENVINO_INSTALL_DIR/setupvars.sh
       env >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ runs:
       INPUT_RELEASE: ${{ inputs.release }}
       INPUT_ARCH: ${{ inputs.arch }}
       INPUT_APT: ${{ inputs.apt }}
+  - run: echo ${{ runner.os }}
+    shell: bash
   - run: |
       sudo apt-get install -y libpugixml1v5
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -40,3 +40,13 @@ runs:
       INPUT_RELEASE: ${{ inputs.release }}
       INPUT_ARCH: ${{ inputs.arch }}
       INPUT_APT: ${{ inputs.apt }}
+  - run: |
+      source $OPENVINO_INSTALL_DIR/setupvars.sh
+      env >> $GITHUB_ENV
+    shell: bash
+    if: ${{ !startsWith(runner.os, 'windows') }}
+  - run: |
+      source ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
+      env >> $GITHUB_ENV
+    shell: bash
+    if: startsWith(runner.os, 'windows')

--- a/action.yml
+++ b/action.yml
@@ -56,3 +56,7 @@ runs:
       env >> $GITHUB_ENV
     shell: bash
     if: ${{ !inputs.apt && startsWith(runner.os, 'windows') }}
+  - run: |
+      find $OPENVINO_INSTALL_DIR -name 'libopenvino.so*' | xargs ldd
+    shell: bash
+    if: ${{ runner.os == 'Linux' }}

--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,8 @@ runs:
       source ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
       env >> $GITHUB_ENV
     shell: bash
-    if: ${{ !inputs.apt && startsWith(runner.os, 'windows') }}
+    if: ${{ inputs.apt == 'false' && startsWith(runner.os, 'windows') }}
   - run: |
       find $OPENVINO_INSTALL_DIR -name 'libopenvino*.so*' | xargs ldd
     shell: bash
-    if: ${{ runner.os == 'Linux' }}
+    if: ${{ inputs.apt == 'false' && runner.os == 'Linux' }}

--- a/action.yml
+++ b/action.yml
@@ -52,9 +52,9 @@ runs:
     shell: bash
     if: ${{ inputs.apt == 'false' && !startsWith(runner.os, 'windows') }}
   - run: |
-      source ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
-      env >> $GITHUB_ENV
-    shell: bash
+      ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
+      set >> $GITHUB_ENV
+    shell: cmd
     if: ${{ inputs.apt == 'false' && startsWith(runner.os, 'windows') }}
   - run: |
       find $OPENVINO_INSTALL_DIR -name 'libopenvino*.so*' | xargs ldd

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,6 +6,4 @@ edition = "2021"
 
 [dependencies]
 env_logger = "0.10"
-openvino = { git = "https://github.com/abrown/openvino-rs", branch = "ci", features = [
-    "runtime-linking",
-] }
+openvino = { version = "0", features = ["runtime-linking"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 
 [dependencies]
 env_logger = "0.10"
-openvino = { version = "0", features = ["runtime-linking"] }
+openvino = { git = "https://github.com/abrown/openvino-rs", branch = "ci", features = [
+    "runtime-linking",
+] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "integration-tests"
+description = "Check that the `openvino-rs` crate can use the environment created by `install-openvino-action`"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+env_logger = "0.10"
+openvino = { version = "0", features = ["runtime-linking"] }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    env_logger::init();
+    println!("> found openvino version: {}", openvino::version());
+}


### PR DESCRIPTION
A simple Rust integration test now will attempt to load the OpenVINO
libraries at runtime using the environment set up by this GitHub action
(i.e., `OPENVINO_INSTALL_DIR`).