### PR TITLE
Ignore extracted directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 *.tgz
 *.zip
 filetree.json
+l_openvino_toolkit*
+m_openvino_toolkit*
+w_openvino_toolkit*


### PR DESCRIPTION
We already ignore the downloaded `*.tgz` and `*.zip` files but when the
installer extracts them in the project directory these big directories
showed up as changed files.