### PR TITLE
Source `setupvars.sh` into the GitHub environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,9 @@ jobs:
         run: find $OPENVINO_INSTALL_DIR
         shell: bash
       - name: Check installation
-        run: $OPENVINO_INSTALL_DIR/setupvars.sh
-        if: matrix.os != 'windows-latest'
-      - name: Check installation
-        run: ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
-        if: matrix.os == 'windows-latest'
-
+        run: integration-tests/check-installation.sh
+        shell: bash
+        if: ${{ startsWith(runner.os, 'linux') }}
 
   old:
     name: Spot-check old archive
@@ -49,10 +46,14 @@ jobs:
         with:
           version: 2022.2
           release: rhel8
+          # We do not use the setup script to prepare the environment due to a conflicting Python
+          # version with the GitHub runner.
+          env: false
       - name: List files
         run: find $OPENVINO_INSTALL_DIR
       - name: Check installation
-        run: $OPENVINO_INSTALL_DIR/setupvars.sh
+        run: integration-tests/check-installation.sh
+        shell: bash
 
   apt:
     name: Check installing APT packages

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Install OpenVINO as a step in a GitHub workflow.
 | `release` |          | Auto-detected, only use to override the release distribution. For Linux, a string indicating which distribution to use, e.g., `ubuntu20`; OpenVINO has packages for various distributions. |
 | `arch`    |          | Auto-detected, only use to override the CPU architecture. One of: `x86_64`, `arm64`. The architecture selection is limited by what packages OpenVINO publishes.                            |
 | `apt`     | false    | Install from [APT packages]; this is limited to Debian-based Linux and limited versions.                                                                                                   |
+| `env`     | true     | Run the OpenVINO setup script to configure the environment (e.g., for library loading).                                                                                                    |
 
 [APT packages]: https://docs.openvino.ai/latest/openvino_docs_install_guides_installing_openvino_apt.html
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Install from APT packages; this is limited to Debian-based Linux and limited
     versions'
     default: false
+  env:
+    description: 'Run the OpenVINO setup script to configure the environment (e.g., for library
+    loading).'
+    default: true
 
 runs:
   using: composite
@@ -40,3 +44,36 @@ runs:
       INPUT_RELEASE: ${{ inputs.release }}
       INPUT_ARCH: ${{ inputs.arch }}
       INPUT_APT: ${{ inputs.apt }}
+  # Linux will need some additional libraries installed.
+  - run: |
+      sudo apt-get install -y libpugixml1v5 libtbb2
+    shell: bash
+    if: ${{ runner.os == 'Linux' }}
+  # Use the OpenVINO scripts to set up the environment for Linux and MacOS. Without some of these (e.g.,
+  # `LD_LIBRARY_PATH`) the OpenVINO runtime is unable to load its dependent libraries.
+  - run: |
+      source $OPENVINO_INSTALL_DIR/setupvars.sh
+      echo InferenceEngine_DIR=$InferenceEngine_DIR >> $GITHUB_ENV
+      echo INTEL_OPENVINO_DIR=$INTEL_OPENVINO_DIR >> $GITHUB_ENV
+      echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH >> $GITHUB_ENV
+      echo ngraph_DIR=$ngraph_DIR >> $GITHUB_ENV
+      echo OpenVINO_DIR=$OpenVINO_DIR >> $GITHUB_ENV
+      echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH >> $GITHUB_ENV
+      echo PYTHONPATH=$PYTHONPATH >> $GITHUB_ENV
+      echo TBB_DIR=$TBB_DIR >> $GITHUB_ENV
+    shell: bash
+    if: ${{ inputs.apt == 'false' && inputs.env == 'true' && !startsWith(runner.os, 'windows') }}
+  # For Windows, we must (1) use `call` to avoid early batch script exits, (2) use the special
+  # `cmd.exe` syntax, and (3) append to the system path via `%GITHUB_PATH%`. This last comes from
+  # inspection of the `setupvars.bat` script and could be fragile, but it seems better than
+  # overriding the entire `%PATH%` variable.
+  - run: |
+      call ${{ env.OPENVINO_INSTALL_DIR }}\setupvars.bat
+      echo InferenceEngine_DIR=%InferenceEngine_DIR% >> %GITHUB_ENV%
+      echo INTEL_OPENVINO_DIR=%INTEL_OPENVINO_DIR% >> %GITHUB_ENV%
+      echo OpenVINO_DIR=%OpenVINO_DIR% >> %GITHUB_ENV%
+      echo OPENVINO_LIB_PATHS=%OPENVINO_LIB_PATHS% >> %GITHUB_ENV%
+      echo TBB_DIR=%TBB_DIR% >> %GITHUB_ENV%
+      echo %OPENVINO_LIB_PATHS% >> %GITHUB_PATH%
+    shell: cmd
+    if: ${{ inputs.apt == 'false' && inputs.env == 'true' && startsWith(runner.os, 'windows') }}

--- a/integration-tests/check-installation.sh
+++ b/integration-tests/check-installation.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Check that the OpenVINO installation is valid (at least on Linux). This verifies that:
+# 1. the `OPENVINO_INSTALL_DIR` environment variable is set
+# 2. we can find some OpenVINO libraries
+# 3. those libraries have no unmet dependencies.
+
+LIBS=(libopenvino.so libopenvino_c.so)
+
+# Check #1: the `OPENVINO_INSTALL_DIR` environment variable is set
+if [ -z $OPENVINO_INSTALL_DIR ]; then
+    echo "> \$OPENVINO_INSTALL_DIR is not set"
+    exit 1
+fi
+
+for LIB in $LIBS; do
+    # Check #2: we can find the OpenVINO libraries
+    FOUND=$(find $OPENVINO_INSTALL_DIR -name $LIB)
+    if [ -z $FOUND ]; then
+        echo "> error: unable to find $LIB in: $OPENVINO_INSTALL_DIR"
+        exit 1
+    fi
+
+    # Check #3: the libraries have no unmet dependencies
+    echo "> found $LIB: $FOUND"
+    if command -v ldd; then
+        DEPENDENCIES="$(ldd $FOUND)"
+        echo "$DEPENDENCIES"
+        if echo $DEPENDENCIES | grep -q "not found"; then
+            echo "> error: $LIB is missing a dependency (is the environment set up correctly?)"
+            exit 1
+        fi
+    fi
+done


### PR DESCRIPTION
Previously, this action only set the `OPENVINO_INSTALL_DIR` environment
variable and left downstream consumers to fend for themselves.
Unfortunately, when OpenVINO is installed from an archive, it expects to
have its `setupvars.sh` script (`setupvars.bat` on Windows) executed.
This is actually a "must-have" because OpenVINO's libraries depend on
other OpenVINO libraries that must be made visible on the system (e.g.,
`LD_LIBRARY_PATH` on Linux). This change tells the
`install-openvino-action` to replace the current GitHub environment with
the one that exists after the `setupvars.sh` script is run (this
persists the environment outside the action).