### PR TITLE
Use latest version with APT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,13 +67,10 @@ jobs:
         uses: ./
         with:
           apt: true
-          # TODO: the latest release (v2023.0.0) is not yet available as an APT package; update this
-          # when it is.
-          version: 2022.3.0
       - name: List files
         run: |
-          apt-cache depends openvino-2022.3.0 --installed
-          dpkg --listfiles libopenvino-2022.3.0
+          apt-cache depends openvino-2022.2.0 --installed
+          dpkg --listfiles libopenvino-2023.2.0
         shell: bash
       - name: Check installation
         run: ldconfig -p | grep openvino

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           apt: true
       - name: List files
         run: |
-          apt-cache depends openvino-2022.2.0 --installed
+          apt-cache depends openvino-2023.2.0 --installed
           dpkg --listfiles libopenvino-2023.2.0
         shell: bash
       - name: Check installation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,10 @@ jobs:
           # We do not use the setup script to prepare the environment due to a conflicting Python
           # version with the GitHub runner.
           env: false
+      # While the action attempts to install needed prerequisites (i.e., TBB), when we start using
+      # non-GitHub-runner versions we may need to tweak this a bit:
+      - name: Install extra version of TBB
+        run: sudo apt-get install -y libtbb2
       - name: List files
         run: find $OPENVINO_INSTALL_DIR
       - name: Check installation

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       INPUT_APT: ${{ inputs.apt }}
   # Linux will need some additional libraries installed.
   - run: |
-      sudo apt-get install -y libpugixml1v5 libtbb2
+      sudo apt-get install -y libpugixml1v5 libtbb12 libtbb2
     shell: bash
     if: ${{ runner.os == 'Linux' }}
   # Use the OpenVINO scripts to set up the environment for Linux and MacOS. Without some of these (e.g.,

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,12 @@ runs:
       INPUT_RELEASE: ${{ inputs.release }}
       INPUT_ARCH: ${{ inputs.arch }}
       INPUT_APT: ${{ inputs.apt }}
-  # Linux will need some additional libraries installed.
+  # Linux will need some additional libraries installed; these can be slightly different based on
+  # the Ubuntu release.
   - run: |
-      sudo apt-get install -y libpugixml1v5 libtbb12 libtbb2
+      OS=$(source /etc/os-release; echo "${ID}${VERSION_ID}")
+      if [[ "$OS" == "ubuntu20.04" ]]; then TBB=libtbb2; else TBB=libtbb12; fi
+      sudo apt-get install -y libpugixml1v5 $TBB
     shell: bash
     if: ${{ runner.os == 'Linux' }}
   # Use the OpenVINO scripts to set up the environment for Linux and MacOS. Without some of these (e.g.,

--- a/main.js
+++ b/main.js
@@ -30,11 +30,6 @@ async function run() {
     let linuxRelease, defaultRelease;
     if (os === 'linux') {
         linuxRelease = await runner.readLinuxRelease(fs.createReadStream('/etc/os-release'));
-        if (linuxRelease.codename === 'jammy') {
-            core.warning('downgrading jammy packages to focal; OpenVINO has no jammy packages but focal should work');
-            linuxRelease.codename = 'focal';
-            linuxRelease.version = '20';
-        }
         defaultRelease = `${linuxRelease.id}${linuxRelease.version}`;
     }
     if (os === 'macos') {
@@ -52,7 +47,7 @@ async function run() {
         if (os !== 'linux') {
             core.warning('retrieving OpenVINO with APT is unlikely to work on OSes other than Linux.');
         }
-        const env = { version, version_year: version.split('.')[0], os_codename: linuxRelease.codename };
+        const env = { version, version_year: version.split('.')[0], os: defaultRelease };
         bash('src/apt.sh', env);
         // TODO cache these APT packages: https://cloudaffaire.com/faq/caching-apt-packages-in-github-actions-workflow/
     } else {

--- a/src/apt.sh
+++ b/src/apt.sh
@@ -7,7 +7,7 @@ set -e
 
 version=${version:-2023.2.0}
 version_year=${version_year:-2023}
-os_codename=${os_codename:-focal}
+os=${os:-ubuntu22}
 
 # Determine the directory of this script. E.g.:
 #  action_dir=/some/directory
@@ -19,13 +19,7 @@ echo "3e1b48a4dbbbaea2b0f442b9ca15821e $action_dir/GPG-PUB-KEY-INTEL-SW-PRODUCTS
 md5sum --check $action_dir/CHECKSUM
 sudo apt-key add $action_dir/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 
-# Warn about the OS codename.
-if [ "$os_codename" == "jammy" ]; then
-    echo "ERROR: OpenVINO has released no 'jammy' (Ubuntu 22.04) packages; use the 'focal' (Ubuntu 20.04) packages instead"
-    exit 1
-fi
-
 # Add the OpenVINO repository and install the OpenVINO DEB package.
-echo "deb https://apt.repos.intel.com/openvino/$version_year $os_codename main" | sudo tee /etc/apt/sources.list.d/intel-openvino-$version_year.list
+echo "deb https://apt.repos.intel.com/openvino/$version_year $os main" | sudo tee /etc/apt/sources.list.d/intel-openvino-$version_year.list
 sudo apt update
 sudo apt install -y openvino-$version

--- a/src/apt.sh
+++ b/src/apt.sh
@@ -5,10 +5,8 @@ set -e
 # Install OpenVINO using APT packages. This script expects to be passed certain variables from
 # `main.js` (it is easier to calculate them there), but for local use these could be set manually.
 
-# TODO: the latest release (v2023.0.0) is not yet available as an APT package; update this when it
-# is.
-version=${version:-2022.3.0}
-version_year=${version_year:-2022}
+version=${version:-2023.2.0}
+version_year=${version_year:-2023}
 os_codename=${os_codename:-focal}
 
 # Determine the directory of this script. E.g.:


### PR DESCRIPTION
According to the OpenVINO [docs], we should now be able to install
OpenVINO with the `apt.sh` script.

[docs]: https://docs.openvino.ai/2023.2/openvino_docs_install_guides_installing_openvino_apt.html#installing-openvino-runtime