### PR TITLE
Inform GitHub action of the release we plan to use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,11 +47,10 @@ runs:
   # Linux will need some additional libraries installed; these can be slightly different based on
   # the Ubuntu release.
   - run: |
-      OS=$(source /etc/os-release; echo "${ID}${VERSION_ID}")
-      if [[ "$OS" == "ubuntu20.04" ]]; then TBB=libtbb2; else TBB=libtbb12; fi
+      if [[ "$_OPENVINO_INSTALL_RELEASE" == "ubuntu20" ]]; then TBB=libtbb2; else TBB=libtbb12; fi
       sudo apt-get install -y libpugixml1v5 $TBB
     shell: bash
-    if: ${{ runner.os == 'Linux' }}
+    if: ${{ inputs.apt == 'false' && runner.os == 'Linux' }}
   # Use the OpenVINO scripts to set up the environment for Linux and MacOS. Without some of these (e.g.,
   # `LD_LIBRARY_PATH`) the OpenVINO runtime is unable to load its dependent libraries.
   - run: |

--- a/main.js
+++ b/main.js
@@ -39,6 +39,7 @@ async function run() {
     if (release === 'ubuntu22' && version.startsWith('2022')) {
         core.warning('downgrading jammy packages to focal; OpenVINO has no jammy packages for this version but focal should work');
         release = 'ubuntu20'
+        // See how this is recorded below in `_OPENVINO_INSTALL_RELEASE`
     }
     core.info(`release: ${release}`);
     const useApt = core.getBooleanInput('apt');
@@ -65,6 +66,9 @@ async function run() {
         const extractedDirectory = path.resolve(path.parse(downloadedFile).name);
         core.info(`Setting up environment: OPENVINO_INSTALL_DIR=${extractedDirectory}`);
         core.exportVariable('OPENVINO_INSTALL_DIR', extractedDirectory);
+        // As long as we still downgrade jammy packages to focal, we need to inform the GitHub
+        // action that we did so.
+        core.exportVariable('_OPENVINO_INSTALL_RELEASE', release);
     }
 }
 


### PR DESCRIPTION
This is a Linux-only hack to avoid dependency failures with TBB; the
`ubuntu20` installation wants `libtbb2` whereas the `ubuntu22`
installation wants `libtbb12`. Since either release can be installed on
either OS, we need to properly install the right dependency (as long as
we aren't using APT, which should just do the right thing).