### PR TITLE
Remove version_year from apt.sh

### DIFF
--- a/src/apt.sh
+++ b/src/apt.sh
@@ -6,7 +6,6 @@ set -e
 # `main.js` (it is easier to calculate them there), but for local use these could be set manually.
 
 version=${version:-2025.1.0}
-version_year=${version_year:-2024}
 release=${release:-ubuntu24}
 
 # Determine the directory of this script. E.g.:
@@ -20,6 +19,6 @@ md5sum --check $action_dir/CHECKSUM
 sudo apt-key add $action_dir/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 
 # Add the OpenVINO repository and install the OpenVINO DEB package.
-echo "deb https://apt.repos.intel.com/openvino/$version_year $release main" | sudo tee /etc/apt/sources.list.d/intel-openvino-$version_year.list
+echo "deb https://apt.repos.intel.com/openvino $release main" | sudo tee /etc/apt/sources.list.d/intel-openvino.list
 sudo apt update
 sudo apt install -y openvino-$version


### PR DESCRIPTION
This fixes a CI failure for getting openvino 2026.x.x due to a [change in repository structure](https://github.com/openvinotoolkit/openvino/releases/tag/2026.1.0) for apt.

> APT & YUM Repositories Restructure: Starting with release 2025.1, users can switch to the new repository structure for APT and YUM, which no longer uses year-based subdirectories (like “2025”). The old (legacy) structure is unavailable starting 2026.0.

This should work for version 2024 onwards, checked by running `apt-cache search openvino`. I don't have a need for 2023 and older versions, but I can introduce a conditional check if backward compatibility with older versions is desired.
